### PR TITLE
Small improvements to Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ This package also provides a convenience wrapper for each function in
 package fmt that takes a format string.
 
 
-# Documentation
+## Documentation
 
 See [GoDoc](http://godoc.org/github.com/kr/pretty) for automatic documentation.
 


### PR DESCRIPTION
Two small improvements to the Readme:
- Updated installation instructions to use "go get' instead of old "goinstall".
- Added link to automatic documentation at GoDoc.org
