### PR TITLE
Label structs when they are members of other structs.

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -2,11 +2,12 @@ package pretty
 
 import (
 	"fmt"
-	"github.com/kr/text"
 	"io"
 	"reflect"
 	"strconv"
 	"text/tabwriter"
+
+	"github.com/kr/text"
 )
 
 const (
@@ -156,7 +157,7 @@ func (p *printer) printValue(v reflect.Value, showType, quote bool) {
 					if expand {
 						writeByte(pp, '\t')
 					}
-					showTypeInStruct = f.Type.Kind() == reflect.Interface
+					showTypeInStruct = labelType(f.Type)
 				}
 				pp.printValue(getField(v, i), showTypeInStruct, true)
 				if expand {
@@ -270,6 +271,14 @@ func canExpand(t reflect.Type) bool {
 	case reflect.Map, reflect.Struct,
 		reflect.Interface, reflect.Array, reflect.Slice,
 		reflect.Ptr:
+		return true
+	}
+	return false
+}
+
+func labelType(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Interface, reflect.Struct:
 		return true
 	}
 	return false

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -19,6 +19,7 @@ type LongStructTypeName struct {
 
 type SA struct {
 	t *T
+	v T
 }
 
 type T struct {
@@ -55,9 +56,10 @@ var gosyntax = []test{
 	},
 	{F(5), "pretty.F(5)"},
 	{
-		SA{&T{1, 2}},
+		SA{&T{1, 2}, T{3, 4}},
 		`pretty.SA{
     t:  &pretty.T{x:1, y:2},
+    v:  pretty.T{x:3, y:4},
 }`,
 	},
 	{


### PR DESCRIPTION
Adds the type label for non-pointer struct fields, since fields that are pointers to structs are usefully labeled.
