### PR TITLE
Detect cyclic references to prevent infinite recursion

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -57,7 +57,7 @@ func (fo formatter) passThrough(f fmt.State, c rune) {
 func (fo formatter) Format(f fmt.State, c rune) {
 	if fo.force || c == 'v' && f.Flag('#') && f.Flag(' ') {
 		w := tabwriter.NewWriter(f, 4, 4, 1, ' ', 0)
-		p := &printer{tw: w, Writer: w}
+		p := &printer{tw: w, Writer: w, visited: make(map[visit]int)}
 		p.printValue(reflect.ValueOf(fo.x), true, fo.quote)
 		w.Flush()
 		return
@@ -67,7 +67,9 @@ func (fo formatter) Format(f fmt.State, c rune) {
 
 type printer struct {
 	io.Writer
-	tw *tabwriter.Writer
+	tw      *tabwriter.Writer
+	visited map[visit]int
+	depth   int
 }
 
 func (p *printer) indent() *printer {
@@ -86,7 +88,19 @@ func (p *printer) printInline(v reflect.Value, x interface{}, showType bool) {
 	}
 }
 
+// printValue must keep track of already-printed pointer values to avoid
+// infinite recursion.
+type visit struct {
+	v   uintptr
+	typ reflect.Type
+}
+
 func (p *printer) printValue(v reflect.Value, showType, quote bool) {
+	if p.depth > 10 {
+		io.WriteString(p, "!%v(DEPTH EXCEEDED)")
+		return
+	}
+
 	switch v.Kind() {
 	case reflect.Bool:
 		p.printInline(v, v.Bool(), showType)
@@ -138,6 +152,16 @@ func (p *printer) printValue(v reflect.Value, showType, quote bool) {
 		writeByte(p, '}')
 	case reflect.Struct:
 		t := v.Type()
+		if v.CanAddr() {
+			addr := v.UnsafeAddr()
+			vis := visit{addr, t}
+			if vd, ok := p.visited[vis]; ok && vd < p.depth {
+				p.fmtString(t.String()+"{(CYCLIC REFERENCE)}", false)
+				break // don't print v again
+			}
+			p.visited[vis] = p.depth
+		}
+
 		if showType {
 			io.WriteString(p, t.String())
 		}
@@ -176,7 +200,9 @@ func (p *printer) printValue(v reflect.Value, showType, quote bool) {
 		case e.Kind() == reflect.Invalid:
 			io.WriteString(p, "nil")
 		case e.IsValid():
-			p.printValue(e, showType, true)
+			pp := *p
+			pp.depth++
+			pp.printValue(e, showType, true)
 		default:
 			io.WriteString(p, v.Type().String())
 			io.WriteString(p, "(nil)")
@@ -221,8 +247,10 @@ func (p *printer) printValue(v reflect.Value, showType, quote bool) {
 			io.WriteString(p, v.Type().String())
 			io.WriteString(p, ")(nil)")
 		} else {
-			writeByte(p, '&')
-			p.printValue(e, true, true)
+			pp := *p
+			pp.depth++
+			writeByte(pp, '&')
+			pp.printValue(e, true, true)
 		}
 	case reflect.Chan:
 		x := v.Pointer()


### PR DESCRIPTION
Alternate implementation to #12. Uses fields on the printer type to track recursion depth and visited pointers.

If you think this is cleaner and you're happy with it, I'll squash to 1 commit.
