### PR TITLE
Also diff slices

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -86,6 +86,16 @@ func (w diffWriter) diff(av, bv reflect.Value) {
 		for i := 0; i < av.NumField(); i++ {
 			w.relabel(at.Field(i).Name).diff(av.Field(i), bv.Field(i))
 		}
+	case reflect.Slice:
+		lenA := av.Len()
+		lenB := bv.Len()
+		if lenA != lenB {
+			w.printf("%s[%d] != %s[%d]", av.Type(), lenA, bv.Type(), lenB)
+			break
+		}
+		for i := 0; i < lenA; i++ {
+			w.relabel(fmt.Sprintf("[%d]", i)).diff(av.Index(i), bv.Index(i))
+		}
 	case reflect.Map:
 		ak, both, bk := keyDiff(av.MapKeys(), bv.MapKeys())
 		for _, k := range ak {

--- a/diff_test.go
+++ b/diff_test.go
@@ -30,8 +30,9 @@ var diffs = []difftest{
 	{S{S: new(S)}, S{S: &S{A: 1}}, []string{`S.A: 0 != 1`}},
 	{S{}, S{I: 0}, []string{`I: nil != 0`}},
 	{S{I: 1}, S{I: "x"}, []string{`I: int != string`}},
-	{S{}, S{C: []int{1}}, []string{`C: []int(nil) != []int{1}`}},
-	{S{C: []int{}}, S{C: []int{1}}, []string{`C: []int{} != []int{1}`}},
+	{S{}, S{C: []int{1}}, []string{`C: []int[0] != []int[1]`}},
+	{S{C: []int{}}, S{C: []int{1}}, []string{`C: []int[0] != []int[1]`}},
+	{S{C: []int{1, 2, 3}}, S{C: []int{1, 2, 4}}, []string{`C[2]: 3 != 4`}},
 	{S{}, S{A: 1, S: new(S)}, []string{`A: 0 != 1`, `S: nil != &{0 <nil> <nil> []}`}},
 }
 


### PR DESCRIPTION
Hi,

Thanks for your library!

Although this PR changes the output when slices are of unequal lengths, I think this is helpful with complex structure comparisons as it tends to find smaller changes. Example output:

```
[["entries"][0]["name"]: "actualName" != "expectedName"]
```
