### PR TITLE
kr/pretty: fix invalid heap pointer bug in tests.

### DIFF
--- a/formatter_test.go
+++ b/formatter_test.go
@@ -45,7 +45,7 @@ var gosyntax = []test{
 	{[0]int{}, "[0]int{}"},
 	{complex(1, 0), "(1+0i)"},
 	//{make(chan int), "(chan int)(0x1234)"},
-	{unsafe.Pointer(uintptr(1)), "unsafe.Pointer(0x1)"},
+	{unsafe.Pointer(uintptr(unsafe.Pointer(&long))), fmt.Sprintf("unsafe.Pointer(0x%02x)", uintptr(unsafe.Pointer(&long)))},
 	{func(int) {}, "func(int) {...}"},
 	{map[int]int{1: 1}, "map[int]int{1:1}"},
 	{int32(1), "int32(1)"},


### PR DESCRIPTION
This fixes an issue in the test with uintptr(1) being an invalid pointer.
The test crashed when running with go1.4 as follows
go test -cpu=4,4,4,4,4,4,4,4,4,4,4,4,4 github.com/kr/pretty