### PR TITLE
Run 'gofmt -w -s' on sources

### DIFF
--- a/formatter_test.go
+++ b/formatter_test.go
@@ -64,13 +64,13 @@ var gosyntax = []test{
 }`,
 	},
 	{
-		map[int][]byte{1: []byte{}},
+		map[int][]byte{1: {}},
 		`map[int][]uint8{
     1:  {},
 }`,
 	},
 	{
-		map[int]T{1: T{}},
+		map[int]T{1: {}},
 		`map[int]pretty.T{
     1:  {},
 }`,


### PR DESCRIPTION
When using 'gofmt -w -s .' in a directory that is godeps'ed, it causes the following change, this is annoying.