### PR TITLE
Use GoStringer interface for structs that support it

### DIFF
--- a/diff_test.go
+++ b/diff_test.go
@@ -15,6 +15,7 @@ type S struct {
 	S *S
 	I interface{}
 	C []int
+	M map[string]int
 }
 
 var diffs = []difftest{
@@ -33,7 +34,10 @@ var diffs = []difftest{
 	{S{}, S{C: []int{1}}, []string{`C: []int[0] != []int[1]`}},
 	{S{C: []int{}}, S{C: []int{1}}, []string{`C: []int[0] != []int[1]`}},
 	{S{C: []int{1, 2, 3}}, S{C: []int{1, 2, 4}}, []string{`C[2]: 3 != 4`}},
-	{S{}, S{A: 1, S: new(S)}, []string{`A: 0 != 1`, `S: nil != &{0 <nil> <nil> []}`}},
+	{S{}, S{A: 1, S: new(S)}, []string{`A: 0 != 1`, `S: nil != &{0 <nil> <nil> [] map[]}`}},
+	{S{}, S{M:map[string]int{"a":2}}, []string{`M["a"]: (missing) != "<int Value>"`}},
+	{S{M:map[string]int{"a":2}}, S{}, []string{`M["a"]: "<int Value>" != (missing)`}},
+	{S{M:map[string]int{"a":1}}, S{M:map[string]int{"a":2}}, []string{`M["a"]: 1 != 2`}},
 }
 
 func TestDiff(t *testing.T) {

--- a/formatter.go
+++ b/formatter.go
@@ -1,7 +1,7 @@
 package pretty
 
 import (
-	"encoding"
+//	"encoding"
 	"fmt"
 	"io"
 	"reflect"
@@ -170,14 +170,9 @@ func (p *printer) printValue(v reflect.Value, showType, quote bool) {
 		printed := false
 		if v.CanInterface() {
 			switch vv := v.Interface().(type) {
-			case fmt.Stringer:
-				p.fmtString(vv.String(), true)
+			case fmt.GoStringer:
+				p.fmtString(vv.GoString(), true)
 				printed = true
-			case encoding.TextMarshaler:
-				if b, err := vv.MarshalText(); err == nil {
-					p.fmtString(string(b), true)
-					printed = true
-				}
 			}
 		}
 		if !printed && nonzero(v) {

--- a/formatter.go
+++ b/formatter.go
@@ -169,12 +169,12 @@ func (p *printer) printValue(v reflect.Value, showType, quote bool) {
 		writeByte(p, '{')
 		printed := false
 		if v.CanInterface() {
-			switch v.Interface().(type) {
+			switch vv := v.Interface().(type) {
 			case fmt.Stringer:
-				p.fmtString(v.Interface().(fmt.Stringer).String(), true)
+				p.fmtString(vv.String(), true)
 				printed = true
 			case encoding.TextMarshaler:
-				if b, err := v.Interface().(encoding.TextMarshaler).MarshalText(); err == nil {
+				if b, err := vv.MarshalText(); err == nil {
 					p.fmtString(string(b), true)
 					printed = true
 				}

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 	"unsafe"
 )
 
@@ -258,4 +259,47 @@ func TestCycle(t *testing.T) {
 	iv := i.I().I().I().I().I().I().I().I().I().I()
 	*iv = *i
 	t.Logf("Example long interface cycle:\n%# v", Formatter(i))
+}
+
+func Test(t *testing.T) {
+	date := time.Date(2006, 1, 2, 3, 4, 5, .678901e9, time.Local)
+
+	s := fmt.Sprintf("%s", Formatter(date))
+
+	if date.String() != s {
+		t.Errorf("expected %s, got %s", date.String(), s)
+	}
+}
+
+type StringerStruct struct{}
+
+func (t StringerStruct) String() string {
+	return "StringerStruct"
+}
+
+func TestStringer(t *testing.T) {
+	s := new(StringerStruct)
+
+	str := fmt.Sprintf("%s", Formatter(s))
+
+	if s.String() != str {
+		t.Errorf("expected %s, got %s", s.String(), str)
+	}
+}
+
+type MarshalTextStruct struct{}
+
+func (t MarshalTextStruct) MarshalText() ([]byte, error) {
+	return []byte("MarshalTextStruct"), nil
+}
+
+func TestMarshalTextStruct(t *testing.T) {
+	s := new(MarshalTextStruct)
+
+	m, _ := s.MarshalText()
+	str := fmt.Sprintf("%s", Formatter(m))
+
+	if string(m) != str {
+		t.Errorf("expected %s, got %s", m, str)
+	}
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -261,45 +261,23 @@ func TestCycle(t *testing.T) {
 	t.Logf("Example long interface cycle:\n%# v", Formatter(i))
 }
 
-func Test(t *testing.T) {
-	date := time.Date(2006, 1, 2, 3, 4, 5, .678901e9, time.Local)
+type GoStringerStruct struct{
+	time.Time
+}
 
-	s := fmt.Sprintf("%s", Formatter(date))
+func (t GoStringerStruct) GoString() string {
+	return t.Format("2006-01-02T15:04:05")
+}
 
-	if date.String() != s {
-		t.Errorf("expected %s, got %s", date.String(), s)
+func TestWithStringer(t *testing.T) {
+	s := GoStringerStruct{time.Date(2015,1,1,0,0,0,0,time.Local)}
+
+	str := fmt.Sprintf("%# v", Formatter(s))
+	goString := "pretty.GoStringerStruct{\""+s.GoString()+"\"}"
+
+	if goString != str {
+		t.Errorf("expected %s, got %s", s.GoString(), str)
 	}
-}
 
-type StringerStruct struct{}
-
-func (t StringerStruct) String() string {
-	return "StringerStruct"
-}
-
-func TestStringer(t *testing.T) {
-	s := new(StringerStruct)
-
-	str := fmt.Sprintf("%s", Formatter(s))
-
-	if s.String() != str {
-		t.Errorf("expected %s, got %s", s.String(), str)
-	}
-}
-
-type MarshalTextStruct struct{}
-
-func (t MarshalTextStruct) MarshalText() ([]byte, error) {
-	return []byte("MarshalTextStruct"), nil
-}
-
-func TestMarshalTextStruct(t *testing.T) {
-	s := new(MarshalTextStruct)
-
-	m, _ := s.MarshalText()
-	str := fmt.Sprintf("%s", Formatter(m))
-
-	if string(m) != str {
-		t.Errorf("expected %s, got %s", m, str)
-	}
+	t.Log(str)
 }


### PR DESCRIPTION
This just changes the great work @otaku has already done to use GoStringer since it is meant for fmt.printf-type statements.  I don't think an additional "(stringer)" message is needed in the output because if someone implements a GoStringer, they've made the choice to see the resulting string in print statements.