### PR TITLE
Pointer to Constant

### DIFF
--- a/formatter_test.go
+++ b/formatter_test.go
@@ -23,6 +23,25 @@ type SA struct {
 	v T
 }
 
+type Addressable struct {
+	b *bool
+	i *int
+	i8 *int8
+	i16 *int16
+	i32 *int32
+	i64 *int64
+	u *uint
+	u8 *uint8
+	u16 *uint16
+	u32 *uint32
+	u64 *uint64
+	f32 *float32
+	f64 *float64
+	c64 *complex64
+	c128 *complex128
+	s *string
+}
+
 type T struct {
 	x, y int
 }
@@ -132,6 +151,44 @@ var gosyntax = []test{
         longFieldName:      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
         otherLongFieldName: nil,
     },
+}`,
+	},
+	{
+		Addressable{
+			b: &[]bool{bool(true)}[0],
+			i: &[]int{int(4)}[0],
+			i8: &[]int8{int8(4)}[0],
+			i16: &[]int16{int16(4)}[0],
+			i32: &[]int32{int32(4)}[0],
+			i64: &[]int64{int64(4)}[0],
+			u: &[]uint{uint(4)}[0],
+			u8: &[]uint8{uint8(4)}[0],
+			u16: &[]uint16{uint16(4)}[0],
+			u32: &[]uint32{uint32(4)}[0],
+			u64: &[]uint64{uint64(4)}[0],
+			f32: &[]float32{float32(4.2)}[0],
+			f64: &[]float64{float64(4.2)}[0],
+			c64: &[]complex64{(4+2i)}[0],
+			c128: &[]complex128{(4+2i)}[0],
+			s: &[]string{"Some string constant."}[0],
+		},
+		`pretty.Addressable{
+    b:    &[]bool{bool(true)}[0],
+    i:    &[]int{int(4)}[0],
+    i8:   &[]int8{int8(4)}[0],
+    i16:  &[]int16{int16(4)}[0],
+    i32:  &[]int32{int32(4)}[0],
+    i64:  &[]int64{int64(4)}[0],
+    u:    &[]uint{uint(0x4)}[0],
+    u8:   &[]uint8{uint8(0x4)}[0],
+    u16:  &[]uint16{uint16(0x4)}[0],
+    u32:  &[]uint32{uint32(0x4)}[0],
+    u64:  &[]uint64{uint64(0x4)}[0],
+    f32:  &[]float32{float32(4.199999809265137)}[0],
+    f64:  &[]float64{float64(4.2)}[0],
+    c64:  &[]complex64{(4+2i)}[0],
+    c128: &[]complex128{(4+2i)}[0],
+    s:    &[]string{"Some string constant."}[0],
 }`,
 	},
 }


### PR DESCRIPTION
The Go language specification does permit references to constants to be
created using the typical syntax[1]:

  &"Some string value."
  &42
  &int32(42)

Additional tooling is necessary to convert constants into their pointer
equivalent. The technique used here is to create a temporary array,
reference the first value, and take the address of that:

  &[]string{"Some string value."}[0]

[1] https://golang.org/ref/spec#Address_operators