### PR TITLE
Detect cyclic references in Fdiff()

### DIFF
--- a/diff_test.go
+++ b/diff_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"strings"
 	"testing"
 	"unsafe"
 )
@@ -190,6 +191,20 @@ func TestFdiff(t *testing.T) {
 	want := "0 != 1\n"
 	if got := buf.String(); got != want {
 		t.Errorf("Fdiff(0, 1) = %q want %q", got, want)
+	}
+}
+
+func TestDiffCycle(t *testing.T) {
+	var buf bytes.Buffer
+	type node struct{ next *node }
+	a := node{}
+	b := node{}
+	a.next = &b
+	b.next = &a
+	Fdiff(&buf, a, b)
+	t.Log(buf.String())
+	if got := buf.String(); !strings.Contains(got, "CYCLIC") {
+		t.Errorf("Cyclic reference not detected, got %q", got)
 	}
 }
 


### PR DESCRIPTION
When diffing two structs a, b where a points to b and b points to a, the diff wouldn't terminate. I'm not sure a diff is meaningful in this case but I've made the code terminate by keeping track of previous pointer compares.