### PR TITLE
Add type string to show the different type and value

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -92,7 +92,7 @@ func (w diffPrinter) diff(av, bv reflect.Value) {
 	at := av.Type()
 	bt := bv.Type()
 	if at != bt {
-		w.printf("%v != %v", at, bt)
+		w.printf("%v (type %s) != %v (type %s)", at, at, bt, bt)
 		return
 	}
 


### PR DESCRIPTION
In some case, when you compare the type and package.type even the value are completely the same. The type is consider different. 
In order to display the different is not in the value but the type itself, we need to print out both the type and package.type in the error message to allow better understanding of the situation
