### PR TITLE
Fix MIT license for pkg.go.dev; tidy go.mod and create go.sum

### DIFF
--- a/License
+++ b/License
@@ -1,5 +1,3 @@
-The MIT License (MIT)
-
 Copyright 2012 Keith Rarick
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module "github.com/kr/pretty"
+module github.com/kr/pretty
 
-require "github.com/kr/text" v0.1.0
+go 1.12
+
+require github.com/kr/text v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=


### PR DESCRIPTION
Currently the documentation for github.com/kr/pretty is not displayed on
pkg.go.dev because of license restrictions:

    https://pkg.go.dev/github.com/kr/pretty?tab=doc

This is almost certainly because the License file includes an errant
header:

    The MIT License (MIT)

The actual MIT license does not include this header:

    https://opensource.org/licenses/MIT

GitHub and other interfaces surface the type of the license through
automatic detection (as will pkg.go.dev). Hence this header is
superfluous in any case.

Whilst we are at it, tidy up go.mod and add go.sum.