### PR TITLE
.github: add a workflow to build and test pushes and pull requests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,17 @@
+name: build-test
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      - uses: actions/checkout@v2
+      - name: Build
+        run: go build .
+      - name: Test
+        run: go test -v .


### PR DESCRIPTION
This pull request adds a simple Github Actions workflow to ensure that the package is buildable and that its tests pass for all pushes and pull requests.

I can't easily verify that this is correct, since workflows are not triggered for pull requests if they don't already exist in the target repository.  I have used this same trivial workflow with other Go packages without problem though.