### PR TITLE
Use github.com/rogpeppe/go-internal/fmtsort for stable map output

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/kr/text"
+	"github.com/rogpeppe/go-internal/fmtsort"
 )
 
 type formatter struct {
@@ -123,10 +124,10 @@ func (p *printer) printValue(v reflect.Value, showType, quote bool) {
 				writeByte(p, '\n')
 				pp = p.indent()
 			}
-			keys := v.MapKeys()
+			sm := fmtsort.Sort(v)
 			for i := 0; i < v.Len(); i++ {
-				k := keys[i]
-				mv := v.MapIndex(k)
+				k := sm.Key[i]
+				mv := sm.Value[i]
 				pp.printValue(k, false, true)
 				writeByte(pp, ':')
 				if expand {

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -38,7 +38,7 @@ func (f F) Format(s fmt.State, c rune) {
 	fmt.Fprintf(s, "F(%d)", int(f))
 }
 
-type Stringer struct { i int }
+type Stringer struct{ i int }
 
 func (s *Stringer) String() string { return "foo" }
 
@@ -74,6 +74,7 @@ var gosyntax = []test{
 	//{make(chan int), "(chan int)(0x1234)"},
 	{unsafe.Pointer(uintptr(unsafe.Pointer(&long))), fmt.Sprintf("unsafe.Pointer(0x%02x)", uintptr(unsafe.Pointer(&long)))},
 	{func(int) {}, "func(int) {...}"},
+	{map[string]string{"a": "a", "b": "b"}, "map[string]string{\"a\":\"a\", \"b\":\"b\"}"},
 	{map[int]int{1: 1}, "map[int]int{1:1}"},
 	{int32(1), "int32(1)"},
 	{io.EOF, `&errors.errorString{s:"EOF"}`},

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/kr/pretty
 
 go 1.12
 
-require github.com/kr/text v0.1.0
+require (
+	github.com/kr/text v0.1.0
+	github.com/rogpeppe/go-internal v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,8 @@
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=


### PR DESCRIPTION
github.com/rogpeppe/go-internal factors out an opinionated selection of
internal packages and functionality from the Go standard library. One
such package is fmtsort:

    Package fmtsort provides a general stable ordering mechanism for
    maps, on behalf of the fmt and text/template packages. It is not
    guaranteed to be efficient and works only for types that are valid
    map keys.

Use this package to ensure the Formatter output for maps is stable.

Fixes #47