### PR TITLE
Add GoStringer support

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -98,6 +98,14 @@ func (p *printer) printValue(v reflect.Value, showType, quote bool) {
 		return
 	}
 
+	if v.IsValid() && v.CanInterface() {
+		i := v.Interface()
+		if goStringer, ok := i.(fmt.GoStringer); ok {
+			io.WriteString(p, goStringer.GoString())
+			return
+		}
+	}
+
 	switch v.Kind() {
 	case reflect.Bool:
 		p.printInline(v, v.Bool(), showType)

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -62,6 +62,19 @@ func TestPassthrough(t *testing.T) {
 	}
 }
 
+type StructWithPrivateFields struct {
+	A string
+	b string
+}
+
+func NewStructWithPrivateFields(a string) StructWithPrivateFields {
+	return StructWithPrivateFields{a, "fixedb"}
+}
+
+func (s StructWithPrivateFields) GoString() string {
+	return fmt.Sprintf("NewStructWithPrivateFields(%q)", s.A)
+}
+
 var gosyntax = []test{
 	{nil, `nil`},
 	{"", `""`},
@@ -84,6 +97,7 @@ var gosyntax = []test{
 		`[]string{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"}`,
 	},
 	{F(5), "pretty.F(5)"},
+	{ NewStructWithPrivateFields("foo"), `NewStructWithPrivateFields("foo")`},
 	{
 		SA{&T{1, 2}, T{3, 4}},
 		`pretty.SA{


### PR DESCRIPTION
Print values using the `GoString()` method (from [`fmt.GoStringer()`](https://golang.org/pkg/fmt/#GoStringer)) if implemented.

This gets the formatter closer the behavior of the `fmt` stdlib.