### PR TITLE
Add slice and array annotation to struct fields

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -21,7 +21,7 @@ type formatter struct {
 // breaks and tabs. Object f responds to the "%v" formatting verb when both the
 // "#" and " " (space) flags are set, for example:
 //
-//     fmt.Sprintf("%# v", Formatter(x))
+//	fmt.Sprintf("%# v", Formatter(x))
 //
 // If one of these two flags is not set, or any other verb is used, f will
 // format x according to the usual rules of package fmt.
@@ -329,7 +329,7 @@ func canExpand(t reflect.Type) bool {
 
 func labelType(t reflect.Type) bool {
 	switch t.Kind() {
-	case reflect.Interface, reflect.Struct:
+	case reflect.Interface, reflect.Struct, reflect.Array, reflect.Slice:
 		return true
 	}
 	return false

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -337,3 +337,27 @@ func TestCycle(t *testing.T) {
 	*iv = *i
 	t.Logf("Example long interface cycle:\n%# v", Formatter(i))
 }
+
+func TestSliceField(t *testing.T) {
+	type MyField struct {
+		Name string
+	}
+	type MyObj struct {
+		Name   string
+		Fields []MyField
+	}
+
+	o := MyObj{
+		Name: "xxx",
+		Fields: []MyField{
+			{
+				Name: "fff",
+			},
+		},
+	}
+
+	s := fmt.Sprintf("%# v", Formatter(o))
+	if strings.Contains(s, "[]MyField") {
+		t.Error("Slice field missing in struct")
+	}
+}


### PR DESCRIPTION
This commit adds slice type when used in the struct field.

Should fix #36 and #45.

To reproduce:

```go
package main

import (
	"github.com/kr/pretty"
)

type MyObj struct {
	Name   string
	Fields []MyField
}

type MyField struct {
	Name string
}

func main() {
	o := MyObj{
		Name: "xxx",
		Fields: []MyField{
			{
				Name: "fff",
			},
		},
	}

	pretty.Println(o)
}
```

Before:

```go
main.MyObj{
    Name:   "xxx",
    Fields: {
        {Name:"fff"},
    },
}
```

after:

```go
main.MyObj{
    Name:   "xxx",
    Fields: []main.MyField{
        {Name:"fff"},
    },
}
```