### PR TITLE
fix wrong cycle detect by clone the map[visit]int

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.13.x
+          go-version: 1.17
       - uses: actions/checkout@v3
       - name: Build
         run: go build .

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -364,3 +364,35 @@ func TestReuseVisitMap(t *testing.T) {
 		t.Error("there should not cycle in ComplexValue ", s)
 	}
 }
+
+type Tree struct {
+	Left  *Tree
+	Value interface{}
+	Right *Tree
+}
+
+func TestCycleRefer(t *testing.T) {
+	var tree = &Tree{
+		Left:  nil,
+		Value: 1,
+		Right: &Tree{
+			Left:  nil,
+			Value: 2,
+			Right: nil,
+		},
+	}
+	var s = Sprint(tree)
+	if strings.Contains(s, "CYCLIC") {
+		t.Error("tree should have no cycle in Tree", s)
+	}
+
+	tree.Right.Value = []interface{}{
+		map[string]interface{}{
+			"refer": tree,
+		},
+	}
+	var s2 = Sprint(tree)
+	if !strings.Contains(s2, "CYCLIC") {
+		t.Error("tree should have no cycle in Tree", s2)
+	}
+}

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -337,3 +337,30 @@ func TestCycle(t *testing.T) {
 	*iv = *i
 	t.Logf("Example long interface cycle:\n%# v", Formatter(i))
 }
+
+type AValue struct {
+	ID   int
+	Name string
+}
+
+type ComplexValue struct {
+	AValues []*AValue
+	Values  []interface{}
+	ByName  map[string]interface{}
+}
+
+func TestReuseVisitMap(t *testing.T) {
+	var a = &AValue{ID: 1, Name: "A"}
+	var c = ComplexValue{
+		AValues: []*AValue{a},
+		Values:  []interface{}{a},
+		ByName: map[string]interface{}{
+			"A": a,
+		},
+	}
+
+	var s = Sprint(c)
+	if strings.Contains(s, "CYCLIC") {
+		t.Error("there should not cycle in ComplexValue ", s)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kr/pretty
 
-go 1.12
+go 1.17
 
 require (
 	github.com/kr/text v0.2.0


### PR DESCRIPTION
use `visited map[visit]int` to check cycle might get some bad case.

the key reason was that, all the `pp`, `p` `printer` share a same  `map[visit]int`

but when we process a struct refer a pointer value twice or more, this is not a cycle, it's just a repeat refer.

maybe use other helper data type for every branch when we call code `pp = *p`  statement 

maybe a `slice` is enough to detect.

```
branch 1 : [v1, v2, v3, v5]
branch 2 : [v1, v2, v3, v4]
branch 3 : [v1, v2, v3, v4, v1]
```
only branch3 should print a "CYCLIC REFERENCE"
